### PR TITLE
feat: mark explicit content, support multiple artists on Tidal

### DIFF
--- a/deezer.py
+++ b/deezer.py
@@ -16,35 +16,78 @@ def env_constructor(loader, node):
 
 yaml.SafeLoader.add_constructor("!env", env_constructor)
 
-if __name__ == '__main__':
-    with open("config.yml", 'r') as f:
+
+async def build_track_entry(el):
+    artist_label = f"Artist: {el['artist']['name']}"
+    album_label = f"Album: {el['album']['title']}"
+    explicit_label = "\nExplicit" if el["explicit_lyrics"] else ""
+
+    await builder.article(
+        title=el["title"],
+        text=el["link"],
+        description=f"{artist_label}\n{album_label}{explicit_label}",
+        thumb=(
+            InputWebDocument(
+                url=el["album"]["cover_medium"],
+                size=0,
+                mime_type="image/jpeg",
+                attributes=[],
+            )
+            if el["album"]["cover_medium"] is not None
+            else None
+        ),
+    )
+
+
+async def build_album_entry(el):
+    artist_label = f"Artist: {el['artist']['name']}"
+    tracks_label = f"Tracks: {el['nb_tracks']}"
+    explicit_label = "\nExplicit" if el["explicit_lyrics"] else ""
+
+    await builder.article(
+        title=el["title"],
+        text=el["link"],
+        description=f"{artist_label}\n{tracks_label}{explicit_label}",
+        thumb=(
+            InputWebDocument(
+                url=el["cover_medium"],
+                size=0,
+                mime_type="image/jpeg",
+                attributes=[],
+            )
+            if el["cover_medium"] is not None
+            else None
+        ),
+    )
+
+
+if __name__ == "__main__":
+    with open("config.yml", "r") as f:
         config = yaml.safe_load(f)
 
     async def start():
         async with aiohttp.ClientSession() as http_sess:
 
             async def track(query, builder, limit=10):
-                async with http_sess.get("https://api.deezer.com/search/track", params={"limit": limit, "q": query}) as resp:
+                async with http_sess.get(
+                    "https://api.deezer.com/search/track",
+                    params={"limit": limit, "q": query},
+                ) as resp:
                     return [
-                        await builder.article(
-                            title=el['title'], text=el['link'],
-                            description=f"Artist: {el['artist']['name']}\nAlbum: {el['album']['title']}",
-                            thumb=InputWebDocument(
-                                url=el['album']['cover_medium'], size=0, mime_type="image/jpeg", attributes=[],
-                            ) if el['album']['cover_medium'] is not None else None
-                        ) for el in (await resp.json())['data'] if el['type'] == "track"
+                        await build_track_entry(el)
+                        for el in (await resp.json())["data"]
+                        if el["type"] == "track"
                     ]
 
             async def album(query, builder, limit=10):
-                async with http_sess.get("https://api.deezer.com/search/album", params={"limit": limit, "q": query}) as resp:
+                async with http_sess.get(
+                    "https://api.deezer.com/search/album",
+                    params={"limit": limit, "q": query},
+                ) as resp:
                     return [
-                        await builder.article(
-                            title=el['title'], text=el['link'],
-                            description=f"Artist: {el['artist']['name']}\nTracks: {el['nb_tracks']}",
-                            thumb=InputWebDocument(
-                                url=el['cover_medium'], size=0, mime_type="image/jpeg", attributes=[],
-                            ) if el['cover_medium'] is not None else None
-                        ) for el in (await resp.json())['data'] if el['type'] == "album"
+                        await build_album_entry(el)
+                        for el in (await resp.json())["data"]
+                        if el["type"] == "album"
                     ]
 
             modes = {
@@ -52,12 +95,12 @@ if __name__ == '__main__':
                 ".t": track,
                 ".track": track,
                 ".a": album,
-                ".album": album
+                ".album": album,
             }
 
             await generic_bot.main(config, modes)
 
     if os.name == "nt":
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-    
+
     asyncio.run(start())

--- a/deezer.py
+++ b/deezer.py
@@ -17,7 +17,7 @@ def env_constructor(loader, node):
 yaml.SafeLoader.add_constructor("!env", env_constructor)
 
 
-async def build_track_entry(el):
+async def build_track_entry(builder, el):
     artist_label = f"Artist: {el['artist']['name']}"
     album_label = f"Album: {el['album']['title']}"
     explicit_label = "\nExplicit" if el["explicit_lyrics"] else ""
@@ -39,7 +39,7 @@ async def build_track_entry(el):
     )
 
 
-async def build_album_entry(el):
+async def build_album_entry(builder, el):
     artist_label = f"Artist: {el['artist']['name']}"
     tracks_label = f"Tracks: {el['nb_tracks']}"
     explicit_label = "\nExplicit" if el["explicit_lyrics"] else ""
@@ -74,7 +74,7 @@ if __name__ == "__main__":
                     params={"limit": limit, "q": query},
                 ) as resp:
                     return [
-                        await build_track_entry(el)
+                        await build_track_entry(builder, el)
                         for el in (await resp.json())["data"]
                         if el["type"] == "track"
                     ]
@@ -85,7 +85,7 @@ if __name__ == "__main__":
                     params={"limit": limit, "q": query},
                 ) as resp:
                     return [
-                        await build_album_entry(el)
+                        await build_album_entry(builder, el)
                         for el in (await resp.json())["data"]
                         if el["type"] == "album"
                     ]

--- a/deezer.py
+++ b/deezer.py
@@ -23,7 +23,7 @@ async def build_track_entry(builder, el):
     explicit_label = "🔞 " if el["explicit_lyrics"] else ""
 
     return await builder.article(
-        title=f"{explicit_label}{el["title"]}",
+        title=f"{explicit_label}{el['title']}",
         text=el["link"],
         description=f"{artist_label}\n{album_label}",
         thumb=(
@@ -45,7 +45,7 @@ async def build_album_entry(builder, el):
     explicit_label = "🔞 " if el["explicit_lyrics"] else ""
 
     return await builder.article(
-        title=f"{explicit_label}{el["title"]}",
+        title=f"{explicit_label}{el['title']}",
         text=el["link"],
         description=f"{artist_label}\n{tracks_label}",
         thumb=(

--- a/deezer.py
+++ b/deezer.py
@@ -20,12 +20,12 @@ yaml.SafeLoader.add_constructor("!env", env_constructor)
 async def build_track_entry(builder, el):
     artist_label = f"Artist: {el['artist']['name']}"
     album_label = f"Album: {el['album']['title']}"
-    explicit_label = "\nExplicit" if el["explicit_lyrics"] else ""
+    explicit_label = "🔞 " if el["explicit_lyrics"] else ""
 
     return await builder.article(
-        title=el["title"],
+        title=f"{explicit_label}{el["title"]}",
         text=el["link"],
-        description=f"{artist_label}\n{album_label}{explicit_label}",
+        description=f"{artist_label}\n{album_label}",
         thumb=(
             InputWebDocument(
                 url=el["album"]["cover_medium"],
@@ -42,12 +42,12 @@ async def build_track_entry(builder, el):
 async def build_album_entry(builder, el):
     artist_label = f"Artist: {el['artist']['name']}"
     tracks_label = f"Tracks: {el['nb_tracks']}"
-    explicit_label = "\nExplicit" if el["explicit_lyrics"] else ""
+    explicit_label = "🔞 " if el["explicit_lyrics"] else ""
 
     return await builder.article(
-        title=el["title"],
+        title=f"{explicit_label}{el["title"]}",
         text=el["link"],
-        description=f"{artist_label}\n{tracks_label}{explicit_label}",
+        description=f"{artist_label}\n{tracks_label}",
         thumb=(
             InputWebDocument(
                 url=el["cover_medium"],

--- a/deezer.py
+++ b/deezer.py
@@ -22,7 +22,7 @@ async def build_track_entry(builder, el):
     album_label = f"Album: {el['album']['title']}"
     explicit_label = "\nExplicit" if el["explicit_lyrics"] else ""
 
-    await builder.article(
+    return await builder.article(
         title=el["title"],
         text=el["link"],
         description=f"{artist_label}\n{album_label}{explicit_label}",
@@ -44,7 +44,7 @@ async def build_album_entry(builder, el):
     tracks_label = f"Tracks: {el['nb_tracks']}"
     explicit_label = "\nExplicit" if el["explicit_lyrics"] else ""
 
-    await builder.article(
+    return await builder.article(
         title=el["title"],
         text=el["link"],
         description=f"{artist_label}\n{tracks_label}{explicit_label}",

--- a/tidal.py
+++ b/tidal.py
@@ -67,7 +67,7 @@ async def build_album_entry(builder, el):
     )
     explicit_label = "\nExplicit" if explicit else ""
 
-    await builder.article(
+    return await builder.article(
         title=el["title"],
         text=el["url"],
         description=f"{artists_label}\n{tracks_label}{explicit_label}",

--- a/tidal.py
+++ b/tidal.py
@@ -29,12 +29,12 @@ async def build_track_entry(builder, el):
 
     artists_label = f"Artists: {artists}" if len(artists) > 1 else f"Artist: {artists}"
     album_label = f"Album: {el['album']['title']}"
-    explicit_label = "\nExplicit" if explicit else ""
+    explicit_label = "🔞 " if explicit else ""
 
     return await builder.article(
-        title,
+        title=f"{explicit_label}{title}",
         text=el["url"],
-        description=f"{artists_label}\n{album_label}{explicit_label}",
+        description=f"{artists_label}\n{album_label}",
         thumb=(
             InputWebDocument(
                 url=f"https://resources.tidal.com/images/{el['album']['cover'].replace('-', '/')}/320x320.jpg",
@@ -54,12 +54,12 @@ async def build_album_entry(builder, el):
 
     artists_label = f"Artists: {artists}" if len(artists) > 1 else f"Artist: {artists}"
     tracks_label = f"Tracks: {el['numberOfTracks']}"
-    explicit_label = "\nExplicit" if explicit else ""
+    explicit_label = "🔞 " if explicit else ""
 
     return await builder.article(
-        title=el["title"],
+        title=f"{explicit_label}{el["title"]}",
         text=el["url"],
-        description=f"{artists_label}\n{tracks_label}{explicit_label}",
+        description=f"{artists_label}\n{tracks_label}",
         thumb=(
             InputWebDocument(
                 url=f"https://resources.tidal.com/images/{el['cover'].replace('-', '/')}/320x320.jpg",

--- a/tidal.py
+++ b/tidal.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import re
 
 from telethon.tl.types import InputWebDocument
 import aiohttp
@@ -25,11 +24,10 @@ async def build_track_entry(builder, el):
         else f"{el['title']} ({el['version']})"
     )
     artists = ", ".join(map(lambda artist: artist["name"], el["artists"]))
-    explicit = el.get("properties", {}).get("content", "") == "explicit"
 
     artists_label = f"Artists: {artists}" if len(artists) > 1 else f"Artist: {artists}"
     album_label = f"Album: {el['album']['title']}"
-    explicit_label = "🔞 " if explicit else ""
+    explicit_label = "🔞 " if el.get("explicit", False) else ""
 
     return await builder.article(
         title=f"{explicit_label}{title}",
@@ -50,14 +48,13 @@ async def build_track_entry(builder, el):
 
 async def build_album_entry(builder, el):
     artists = ", ".join(map(lambda artist: artist["name"], el["artists"]))
-    explicit = el.get("properties", {}).get("content", "") == "explicit"
 
     artists_label = f"Artists: {artists}" if len(artists) > 1 else f"Artist: {artists}"
     tracks_label = f"Tracks: {el['numberOfTracks']}"
-    explicit_label = "🔞 " if explicit else ""
+    explicit_label = "🔞 " if el.get("explicit", False) else ""
 
     return await builder.article(
-        title=f"{explicit_label}{el["title"]}",
+        title=f"{explicit_label}{el['title']}",
         text=el["url"],
         description=f"{artists_label}\n{tracks_label}",
         thumb=(

--- a/tidal.py
+++ b/tidal.py
@@ -24,17 +24,11 @@ async def build_track_entry(builder, el):
         if "version" not in el or not el["version"]
         else f"{el['title']} ({el['version']})"
     )
-
     artists = ", ".join(map(lambda artist: artist["name"], el["artists"]))
+    explicit = el.get("properties", {}).get("content", "") == "explicit"
+
     artists_label = f"Artists: {artists}" if len(artists) > 1 else f"Artist: {artists}"
-
-    album_label = f"Album: {el['album'['title']]}"
-
-    explicit = (
-        el["properties"]["content"] == "explicit"
-        if hasattr(el, "properties") and hasattr(el["properties"], "content")
-        else False
-    )
+    album_label = f"Album: {el['album']['title']}"
     explicit_label = "\nExplicit" if explicit else ""
 
     return await builder.article(
@@ -56,15 +50,10 @@ async def build_track_entry(builder, el):
 
 async def build_album_entry(builder, el):
     artists = ", ".join(map(lambda artist: artist["name"], el["artists"]))
+    explicit = el.get("properties", {}).get("content", "") == "explicit"
+
     artists_label = f"Artists: {artists}" if len(artists) > 1 else f"Artist: {artists}"
-
     tracks_label = f"Tracks: {el['numberOfTracks']}"
-
-    explicit = (
-        el["properties"]["content"] == "explicit"
-        if hasattr(el, "properties") and hasattr(el["properties"], "content")
-        else False
-    )
     explicit_label = "\nExplicit" if explicit else ""
 
     return await builder.article(

--- a/tidal.py
+++ b/tidal.py
@@ -18,7 +18,7 @@ def env_constructor(loader, node):
 yaml.SafeLoader.add_constructor("!env", env_constructor)
 
 
-async def build_track_entry(el):
+async def build_track_entry(builder, el):
     title = (
         el["title"]
         if "version" not in el or not el["version"]
@@ -54,7 +54,7 @@ async def build_track_entry(el):
     )
 
 
-async def build_album_entry(el):
+async def build_album_entry(builder, el):
     artists = ", ".join(map(lambda artist: artist["name"], el["artists"]))
     artists_label = f"Artists: {artists}" if len(artists) > 1 else f"Artist: {artists}"
 
@@ -116,7 +116,7 @@ if __name__ == "__main__":
                     headers={"x-tidal-token": token},
                 ) as resp:
                     return [
-                        await build_track_entry(el)
+                        await build_track_entry(builder, el)
                         for el in (await resp.json())["tracks"]["items"]
                     ]
 
@@ -138,7 +138,7 @@ if __name__ == "__main__":
                     headers={"x-tidal-token": token},
                 ) as resp:
                     return [
-                        build_album_entry(el)
+                        build_album_entry(builder, el)
                         for el in (await resp.json())["albums"]["items"]
                     ]
 


### PR DESCRIPTION
Marks tracks and albums with explicit lyrics as "Explicit".
On top of that I've extracted building articles to their own functions, so it is easier to read and maintain.
I have also ran Black formatter, as I couldn't find any mention of what should be used to format code.

code isn't tested, please actually review :^)